### PR TITLE
Added feature for override trailpacks configs from the application config

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,56 @@ module.exports = class Trailpack {
       throw new Error('Trailpack is missing package definition ("pack.pkg")')
     }
     if (!pack.config) {
-      pack.config = { }
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack is missing package configuration ("pack.config")')
     }
     if (!pack.config.trailpack) {
-      pack.config.trailpack = { }
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack is missing configuration ("pack.config.trailpack")')
     }
+    if (!pack.config.trailpack.lifecycle
+        || typeof pack.config.trailpack.lifecycle !== 'object' ) {
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack lifecycle configuration should be an object ' +
+          '("pack.config.trailpack.lifecycle")')
+    }
+    if (!pack.config.trailpack.lifecycle.configure
+        || typeof pack.config.trailpack.lifecycle.configure !== 'object' ) {
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack lifecycle configuration should be an object ' +
+          '("pack.config.trailpack.lifecycle.configure")')
+    }
+    if (!pack.config.trailpack.lifecycle.configure.listen
+        || !Array.isArray(pack.config.trailpack.lifecycle.configure.listen) ) {
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack lifecycle configuration listeners should be an array ' +
+          '("pack.config.trailpack.lifecycle.configure.listen")')
+    }
+    if (!pack.config.trailpack.lifecycle.configure.emit
+        || !Array.isArray(pack.config.trailpack.lifecycle.configure.emit)) {
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack lifecycle configuration emitters should be an array ' +
+          '("pack.config.trailpack.lifecycle.configure.emit")')
+    }
+    if (!pack.config.trailpack.lifecycle.initialize
+        || typeof pack.config.trailpack.lifecycle.initialize !== 'object' ) {
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack lifecycle initialize should be an object ' +
+          '("pack.config.trailpack.lifecycle.initialize")')
+    }
+    if (!pack.config.trailpack.lifecycle.initialize.listen
+        || !Array.isArray(pack.config.trailpack.lifecycle.initialize.listen) ) {
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack lifecycle initialize listeners should be an array ' +
+          '("pack.config.trailpack.lifecycle.initialize.listen")')
+    }
+    if (!pack.config.trailpack.lifecycle.initialize.emit
+        || !Array.isArray(pack.config.trailpack.lifecycle.initialize.emit) ) {
+      throw new Error('[' + pack.pkg.name + '] ' +
+          'Trailpack lifecycle initialize emitters should be an array ' +
+          '("pack.config.trailpack.lifecycle.initialize.emit")')
+    }
+
 
     Object.defineProperties(this, {
       app: {

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = class Trailpack {
       }
     })
 
+    lib.Util.mergeApplicationTrailpackConfig(this.app, pack)
     lib.Util.mergeApplication(this.app, pack)
     lib.Util.mergeApplicationConfig(this.app, pack)
     lib.Util.mergeEnvironmentConfig(pack.config, this.app.config)

--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = class Trailpack {
     if (!pack.config) {
       pack.config = { }
     }
+    if (!pack.config.trailpack) {
+      pack.config.trailpack = { }
+    }
 
     Object.defineProperties(this, {
       app: {

--- a/index.js
+++ b/index.js
@@ -26,56 +26,22 @@ module.exports = class Trailpack {
       throw new Error('Trailpack is missing package definition ("pack.pkg")')
     }
     if (!pack.config) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack is missing package configuration ("pack.config")')
+        pack.config = {}
     }
     if (!pack.config.trailpack) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack is missing configuration ("pack.config.trailpack")')
+        pack.config.trailpack = {
+            lifecycle: {
+                initialize: {
+                    listen: [],
+                    emit: []
+                },
+                configure: {
+                    listen: [],
+                    emit: []
+                }
+            }
+        }
     }
-    if (!pack.config.trailpack.lifecycle
-        || typeof pack.config.trailpack.lifecycle !== 'object' ) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack lifecycle configuration should be an object ' +
-          '("pack.config.trailpack.lifecycle")')
-    }
-    if (!pack.config.trailpack.lifecycle.configure
-        || typeof pack.config.trailpack.lifecycle.configure !== 'object' ) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack lifecycle configuration should be an object ' +
-          '("pack.config.trailpack.lifecycle.configure")')
-    }
-    if (!pack.config.trailpack.lifecycle.configure.listen
-        || !Array.isArray(pack.config.trailpack.lifecycle.configure.listen) ) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack lifecycle configuration listeners should be an array ' +
-          '("pack.config.trailpack.lifecycle.configure.listen")')
-    }
-    if (!pack.config.trailpack.lifecycle.configure.emit
-        || !Array.isArray(pack.config.trailpack.lifecycle.configure.emit)) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack lifecycle configuration emitters should be an array ' +
-          '("pack.config.trailpack.lifecycle.configure.emit")')
-    }
-    if (!pack.config.trailpack.lifecycle.initialize
-        || typeof pack.config.trailpack.lifecycle.initialize !== 'object' ) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack lifecycle initialize should be an object ' +
-          '("pack.config.trailpack.lifecycle.initialize")')
-    }
-    if (!pack.config.trailpack.lifecycle.initialize.listen
-        || !Array.isArray(pack.config.trailpack.lifecycle.initialize.listen) ) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack lifecycle initialize listeners should be an array ' +
-          '("pack.config.trailpack.lifecycle.initialize.listen")')
-    }
-    if (!pack.config.trailpack.lifecycle.initialize.emit
-        || !Array.isArray(pack.config.trailpack.lifecycle.initialize.emit) ) {
-      throw new Error('[' + pack.pkg.name + '] ' +
-          'Trailpack lifecycle initialize emitters should be an array ' +
-          '("pack.config.trailpack.lifecycle.initialize.emit")')
-    }
-
 
     Object.defineProperties(this, {
       app: {

--- a/lib/util.js
+++ b/lib/util.js
@@ -86,6 +86,16 @@ module.exports = {
     })
   },
 
+  /**
+   * Override the trailpack's config with application definition per trailpack
+   */
+  mergeApplicationTrailpackConfig (app, pack) {
+    if (app.config.main.packsConfig[pack.pkg.name]){
+      return _.merge(pack.config.trailpack, app.config.main.packsConfig[pack.pkg.name])
+    }
+    return
+  },
+
   mergeDefaultTrailpackConfig (packConfig, defaultConfig) {
     return _.defaultsDeep(packConfig || { }, defaultConfig.trailpack)
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^2.11.1",
     "eslint-config-trails": "^1.0.7",
     "mocha": "^2.5.0",
-    "trails": "^1.0.3",
+    "trails": "catrielmuller/trails#config-trailpacks-in-app",
     "smokesignals": "^1.2.2"
   },
   "engines": {

--- a/test/app.js
+++ b/test/app.js
@@ -34,6 +34,11 @@ const App = {
       }
     },
     main: {
+      packsConfig: {
+        'trailpack-test': {
+          testattr: 'testvalue'
+        }
+      },
       packs: [
         smokesignals.Trailpack,
         require('./pack')

--- a/test/app.js
+++ b/test/app.js
@@ -35,8 +35,12 @@ const App = {
     },
     main: {
       packsConfig: {
-        'trailpack-test': {
-          testattr: 'testvalue'
+        'trailpack-testpack': {
+          lifecycle: {
+            initialize: {
+              emit: ['trailpack:testpack:custom']
+            }
+          }
         }
       },
       packs: [

--- a/test/pack.js
+++ b/test/pack.js
@@ -9,7 +9,19 @@ module.exports = class TestPack extends Trailpack {
         name: 'trailpack-testpack'
       },
       config: {
-        mypack: {}
+        mypack: {},
+        trailpack: {
+          lifecycle: {
+            configure: {
+              listen: [],
+              emit: []
+            },
+            initialize: {
+              listen: [],
+              emit: []
+            }
+          }
+        }
       }
     })
   }

--- a/test/pack/config/trailpack.js
+++ b/test/pack/config/trailpack.js
@@ -4,34 +4,27 @@
  * @see {@link http://trailsjs.io/doc/trailpack/config
  */
 module.exports = {
-
+  type: 'misc',
   /**
-   * API and config resources provided by this Trailpack.
+   * Configure the lifecycle of this pack; that is, how it boots up, and which
+   * order it loads relative to other trailpacks.
    */
-  provides: {
-    api: {
-      controllers: [ ]
-      // ...
-    },
-    config: [ ]
-  },
-
-  events: {
+  lifecycle: {
     configure: {
       /**
        * List of events that must be fired before the configure lifecycle
        * method is invoked on this Trailpack
        */
-      listen: [ ],
+      listen: [],
 
       /**
        * List of events emitted by the configure lifecycle method
        */
-      emit: [ ]
+      emit: []
     },
     initialize: {
-      listen: [ ],
-      emit: [ ]
+      listen: [],
+      emit: []
     }
   }
 }

--- a/test/pack/index.js
+++ b/test/pack/index.js
@@ -1,16 +1,14 @@
 'use strict'
 
-const app = {
-  config: require('./config')
-}
 const Trailpack = require('../../')
 
 module.exports = class TestPack extends Trailpack {
 
-  constructor () {
+  constructor (app) {
     super(app, {
       config: require('./config'),
       pkg: require('./package')
     })
   }
+
 }

--- a/test/trailpack.test.js
+++ b/test/trailpack.test.js
@@ -16,8 +16,10 @@ describe('Trailpack', () => {
       new TestPack(global.app)
     })
     it('should override the trailpack config', () => {
+      global.app.after('trailpack:testpack:constructed').then(() => {
+        assert.equal(pack.config.lifecycle.initialize.emit[0], 'trailpack:testpack:custom')
+      })
       const pack = new TestPack(global.app)
-      assert.equal(pack.config.trailpack.testattr, 'testvalue')
     })
   })
 

--- a/test/trailpack.test.js
+++ b/test/trailpack.test.js
@@ -15,6 +15,10 @@ describe('Trailpack', () => {
       global.app.after('trailpack:testpack:constructed').then(() => done() )
       new TestPack(global.app)
     })
+    it('should override the trailpack config', () => {
+      const pack = new TestPack(global.app)
+      assert.equal(pack.config.trailpack.testattr, 'testvalue')
+    })
   })
 
   describe('#name', () => {
@@ -45,5 +49,6 @@ describe('Trailpack', () => {
       pack.log.debug('hello')
     })
   })
+
 })
 


### PR DESCRIPTION
In some cases one trailpack run some functionalities from the application, for example.
If you implement a tasker trailpack for run tasks in background and this task need a orm, In the startup of the application if the tasker module are loaded before the orm module this fails cos app.orm is undefined.
But this not is a problem of the tasker trailpack cos this module dont need an orm really (If you use as standalone).
For solve this problem and another case like the order on startup app as you want.
I propose include a new attribute in the config/main.js  "packsConfig" and inside of this you can override the trailpacks configs like this:

``` javascript
packsConfig: {
    'trailpack-tasker': {
      lifecycle: {
        initialize: {
          listen: ['trailpack:waterline:initialized']
        }
      }
    },
    'trailpack-cron': {
      lifecycle: {
        initialize: {
          listen: ['trailpack:tasker:initialized']
        }
      }
    }
  },
```

As well also you can override this attribute per enviroment.
